### PR TITLE
ESP32-Flask HTTP 통신으로 전환

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,11 @@
     "allow": [
       "Bash(gh issue view:*)",
       "Bash(git -C C:/Users/reliq/projects/IoT_programming log --oneline --all)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(cat:*)",
+      "WebFetch(domain:docs.espressif.com)",
+      "Bash(gh issue:*)",
+      "WebFetch(domain:esp32io.com)"
     ]
   }
 }

--- a/0224/app.py
+++ b/0224/app.py
@@ -1,52 +1,54 @@
-from flask import Flask, render_template, jsonify
-import time
-from datetime import datetime 
-import serial
+# [수정] request 추가 - ESP32에서 보낸 POST 데이터를 받기 위해 필요
+from flask import Flask, render_template, jsonify, request
+# [삭제] import time - HTTP 방식에서는 불필요
+# [삭제] import serial - USB 시리얼 통신 대신 HTTP 통신 사용
+from datetime import datetime
 
 app = Flask(__name__)
 
-def read_sensor():
-    try:
-        ser = serial.Serial('/dev/ttyUSB0', 9600, timeout=3)
-        time.sleep(2)
-        line = ser.readline().decode('utf-8').rstrip()
-        ser.close()
+# [추가] ESP32에서 HTTP로 받은 최신 센서 데이터를 저장하는 변수
+latest_sensor = {"temperature": None, "humidity": None}
 
-        humidity, celsius = line.split(',')
-        return {
-            "temperature": float(celsius),
-            "humidity": float(humidity)
-        }
-    except Exception as e:
-        print("센서 오류: ", e)
-        return {"temperature": None, "humidity":None}
+# [삭제] read_sensor() 함수 - Serial 통신 방식이므로 더 이상 불필요
+#def read_sensor():
+#    try:
+#        ser = serial.Serial('/dev/ttyUSB0', 9600, timeout=3)
+#        time.sleep(2)
+#        line = ser.readline().decode('utf-8').rstrip()
+#        ser.close()
+#
+#        humidity, celsius = line.split(',')
+#        return {
+#            "temperature": float(celsius),
+#            "humidity": float(humidity)
+#        }
+#    except Exception as e:
+#        print("센서 오류: ", e)
+#        return {"temperature": None, "humidity":None}
 
 @app.route('/')
 def index():
-    #data = {"temperature": 28.1, "humidity": 60.5}
-    #return "온도: 25.3, 습도: 60.5"
-    #return "<h1>온도: 25.3</h1><p>습도: 60.5</p>"
-    #return render_template("index.html", sensor=data)
-
-    #records = [
-        #{"temperature": 25.3, "humidity":60.5},
-        #{"temperature": 27.1, "humidity":58.2},
-        #{"temperature": 29.4, "humidity":55.0},
-        #{"temperature": 23.8, "humidity":65.3},
-    #]
-    data = read_sensor()
-    #now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    # [수정] read_sensor() 대신 latest_sensor 변수에서 데이터를 가져옴
     now = datetime.now().strftime("%Y년%m월%d일 %H:%M")
-    #return render_template("index.html", records=records)
-    #return render_template("index.html", data=records, now=now)
-    #return render_template("index.html", data=[], now=now)
-    return render_template("index.html", sensor=data, now=now)
+    return render_template("index.html", sensor=latest_sensor, now=now)
 
-#@app.route('/api/sensor')
-#def api_sensor():
-    #data = {"temperature": 25.3, "humidity":60.5}
-    #return jsonify(data)
+# [추가] ESP32가 센서 데이터를 POST로 보내는 엔드포인트
+@app.route('/api/sensor', methods=['POST'])
+def receive_sensor():
+    global latest_sensor
+    data = request.get_json()
+    latest_sensor = {
+        "temperature": data.get("temperature"),
+        "humidity": data.get("humidity")
+    }
+    print(f"수신: 온도={latest_sensor['temperature']}, 습도={latest_sensor['humidity']}")
+    return jsonify({"status": "ok"})
+
+# [추가] 현재 저장된 센서 데이터를 확인하는 GET 엔드포인트 (테스트용)
+@app.route('/api/sensor', methods=['GET'])
+def get_sensor():
+    return jsonify(latest_sensor)
 
 if __name__ == '__main__':
-
-    app.run(debug=True)
+    # [수정] host='0.0.0.0' 추가 - ESP32(외부 기기)가 접속할 수 있도록 허용
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/0224/esp32_http/esp32_http.ino
+++ b/0224/esp32_http/esp32_http.ino
@@ -1,0 +1,63 @@
+// ESP32 → Flask 서버 HTTP 접속 테스트 코드
+// 센서 없이 더미 데이터로 통신 확인용
+
+#include <WiFi.h>
+#include <HTTPClient.h>
+
+// ===== WiFi 설정 =====
+// [수정 필요] 사용하는 WiFi 이름과 비밀번호로 변경
+const char* ssid = "YOUR_WIFI_SSID";
+const char* password = "YOUR_WIFI_PASSWORD";
+
+// ===== Flask 서버 설정 =====
+// [수정 필요] Flask 서버가 실행 중인 PC의 IP 주소로 변경
+// PC에서 ifconfig 또는 ip addr 명령어로 확인
+String serverURL = "http://192.168.0.100:5000/api/sensor";
+
+void setup() {
+  Serial.begin(115200);
+
+  // WiFi 연결
+  WiFi.begin(ssid, password);
+  Serial.print("WiFi 연결 중");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("WiFi 연결 완료! IP: ");
+  Serial.println(WiFi.localIP());
+}
+
+void loop() {
+  // WiFi 연결 상태 확인 후 HTTP POST 전송
+  if (WiFi.status() == WL_CONNECTED) {
+    HTTPClient http;
+
+    http.begin(serverURL);
+    http.addHeader("Content-Type", "application/json");
+
+    // 더미 데이터로 테스트 (센서 연결 전 통신 확인용)
+    String jsonData = "{\"temperature\":25.3,\"humidity\":60.5}";
+
+    int httpCode = http.POST(jsonData);
+
+    if (httpCode > 0) {
+      String response = http.getString();
+      Serial.print("서버 응답 코드: ");
+      Serial.println(httpCode);
+      Serial.print("서버 응답: ");
+      Serial.println(response);
+    } else {
+      Serial.print("전송 실패, 에러코드: ");
+      Serial.println(httpCode);
+    }
+
+    http.end();
+  } else {
+    Serial.println("WiFi 연결 끊김!");
+  }
+
+  // 5초마다 전송
+  delay(5000);
+}


### PR DESCRIPTION
## Summary
- Flask app.py: Serial(USB) 통신 방식을 HTTP POST/GET 방식으로 전환
- ESP32 Arduino 코드: WiFi 접속 및 HTTP POST 테스트 코드 추가 (더미 데이터)
- Flask 서버를 0.0.0.0으로 바인딩하여 ESP32 외부 접근 허용

## Test plan
- [ ] Flask 서버 실행 후 curl로 POST /api/sensor 테스트
- [ ] 브라우저에서 GET /api/sensor로 데이터 확인
- [ ] ESP32에 WiFi 정보/서버 IP 설정 후 업로드하여 통신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)